### PR TITLE
fixed an issue with parsing a receipt when there is an empty in_app a…

### DIFF
--- a/app/parse/common/purchase/index.ts
+++ b/app/parse/common/purchase/index.ts
@@ -18,8 +18,8 @@ export const parsePurchases = (
   latestReceiptInfo?: AppleLatestReceiptInfo[],  
   inAppTransactions?: AppleInAppPurchaseTransaction[]    
 ): ProductPurchases[] => {
-  if (!inAppTransactions) return []
-
+  if (!inAppTransactions || inAppTransactions.length == 0) return []
+  
   const parsedPurchases = new ParsedPurchases()
 
   inAppTransactions.concat(latestReceiptInfo as AppleInAppPurchaseTransaction[])


### PR DESCRIPTION
I noticed that Apple returns a receipt with an empty "in_app" array for an app without subscriptions. The lib was failing to parse such receipts. Fixed that.

```
{
	"environment": "Sandbox",
	"receipt": {
		"receipt_type": "ProductionSandbox",
		"adam_id": 0,
		"app_item_id": 0,
		"bundle_id": "com.foo.foo",
		"application_version": "1",
		"download_id": 0,
		"version_external_identifier": 0,
		"receipt_creation_date": "2020-11-13 01:46:37 Etc/GMT",
		"receipt_creation_date_ms": "1605231997000",
		"receipt_creation_date_pst": "2020-11-12 17:46:37 America/Los_Angeles",
		"request_date": "2020-11-13 01:47:08 Etc/GMT",
		"request_date_ms": "1605232028848",
		"request_date_pst": "2020-11-12 17:47:08 America/Los_Angeles",
		"original_purchase_date": "2013-08-01 07:00:00 Etc/GMT",
		"original_purchase_date_ms": "1375340400000",
		"original_purchase_date_pst": "2013-08-01 00:00:00 America/Los_Angeles",
		"original_application_version": "1.0",
		"in_app": []
	},
	"latest_receipt": "XXXXXX",
	"status": 2
}
```